### PR TITLE
refactor: Refactoring consul payload models

### DIFF
--- a/agent_discovery/app/models/consul_models.py
+++ b/agent_discovery/app/models/consul_models.py
@@ -1,14 +1,7 @@
 from enum import Enum
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
-from pydantic import BaseModel, Field, HttpUrl
-
-from agents.common.types import (
-    AgentAuthentication,
-    AgentCapabilities,
-    AgentProvider,
-    AgentSkill,
-)
+from pydantic import BaseModel, Field, HttpUrl, RootModel
 
 
 class HealthStatus(str, Enum):
@@ -18,29 +11,16 @@ class HealthStatus(str, Enum):
     maintenance = "maintenance"
 
 
-class AgentServiceMeta(BaseModel):
-    provider: AgentProvider = Field(...)
-    modalities: List[str] = Field(default_factory=list)
-    version: Optional[str] = Field(None)
-    description: Optional[str] = Field(None)
-    documentation_url: Optional[str] = Field(None)
-    capabilities: AgentCapabilities = Field(...)
-    authentication: Optional[AgentAuthentication] = Field(None)
-    default_input_modes: List[str] = Field(default_factory=list)
-    default_output_modes: List[str] = Field(default_factory=list)
-    skills: List[AgentSkill] = Field(default_factory=list)
+class AddressValue(RootModel[Annotated[str, Field(min_length=1, max_length=255)]]):
+    pass
 
 
-class AddressValue(BaseModel):
-    value: str = Field(..., min_length=1, max_length=255)
+class PortValue(RootModel[Annotated[int, Field(ge=1, le=65535)]]):
+    pass
 
 
-class PortValue(BaseModel):
-    value: int = Field(..., ge=1, le=65535)
-
-
-class DurationValue(BaseModel):
-    value: str = Field(..., pattern=r"^\d+(ms|s|m|h)$")
+class DurationValue(RootModel[Annotated[str, Field(pattern=r"^\d+(ms|s|m|h)$")]]):
+    pass
 
 
 class CheckConfig(BaseModel):
@@ -55,7 +35,7 @@ class ConsulServiceDefinition(BaseModel):
     Address: AddressValue = Field(...)
     Port: PortValue = Field(...)
     Tags: List[str] = Field(default_factory=list)
-    Meta: AgentServiceMeta = Field(...)
+    Meta: dict[str, str] = Field(...)
     Check: Optional[CheckConfig] = Field(None)
 
 
@@ -69,7 +49,7 @@ class ServiceEntry(BaseModel):
     Address: AddressValue = Field(...)
     Port: PortValue = Field(...)
     Tags: List[str] = Field(default_factory=list)
-    Meta: AgentServiceMeta = Field(...)
+    Meta: dict[str, str] = Field(...)
 
 
 class HealthCheckResult(BaseModel):


### PR DESCRIPTION
# ✨ PR: Simplify Consul Meta to use only `agent_card_url` (A2A Discovery Compliance)

## 📌 변경 목적 (Why)

- A2A 표준의 Discovery Mechanism은 각 Agent가 자기 기술(self-description) 정보를 `/.well-known/agent.json`에서 JSON으로 제공하도록 명시하고 있습니다.
- 기존 방식에서는 Consul `Meta` 필드에 `AgentServiceMeta.to_meta()`를 통해 평탄화된 모든 메타데이터를 넣고 있었지만,
  - 표현력이 떨어지고
  - Consul의 key 제약 (`dict[str, str]`) 때문에 정보 왜곡이 발생하며
  - A2A 구조와 일치하지 않는 문제가 있었습니다.

이에 따라 Consul에는 AgentCard의 위치만 명시하고, 메타 정보는 Agent 스스로 제공하도록 구조를 단순화했습니다.

---

## ✅ 주요 변경 내용 (What)

- Consul `Meta` 필드에서 `agent_card_url`만 포함하도록 수정
- `AgentServiceMeta.to_meta()` 사용 제거
- 서비스 등록 코드에서 평탄화 로직 제거 및 `.well-known/agent.json` 경로로 URL 자동 생성
- Consul 등록 시 전체 AgentCard 정보를 직접 포함하지 않음

---

## 🧪 테스트 시나리오 (How to Test)

1. 서비스 실행 후 `Consul UI` 또는 API에서 `agent_card_url` 메타 필드가 포함되어 있는지 확인
2. 브라우저 또는 HTTP 클라이언트로 `http://{agent_host}:{port}/.well-known/agent.json` 호출
   - 응답으로 A2A AgentCard JSON이 내려와야 함
3. Orchestrator 또는 Discovery Client가 `Meta.agent_card_url`을 기반으로 AgentCard를 성공적으로 파싱할 수 있어야 함

---

## 📈 기대 효과 (Impact)

| 항목 | 효과 |
|------|------|
| 🔄 표준 준수 | A2A Discovery Mechanism 및 RFC 8615 완전 대응 |
| 🧩 구조 명확화 | Consul은 위치만, Agent는 정보 제공자로 역할 분리 |
| 🔧 유지보수 향상 | 복잡한 직렬화/역직렬화 로직 제거 |
| 🤖 LLM-Friendly | LLM 기반 오케스트레이터가 JSON 구조 그대로 활용 가능 |

---

## 📎 관련 이슈

- closes #18 

---

## 🚧 참고 사항

- 추후 `/agent-card` 대신 `.well-known/agent.json`을 사용하는 엔드포인트도 통일 필요
- 기존 `to_meta()` 기반의 테스트 코드 및 변환 로직은 deprecated 예정
